### PR TITLE
Patch to work with DateTime trial releases

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Changes for Media::DateTime
 
+    * Fix to work with possible future DateTime versions that throw different
+      exceptions when parameters are invalid. Patch by Dave Rolsky. GitHub PR
+      #1.
+
 0.48 - Tue Mar 11 18:03:37 EDT 2014
     * Adds version to JPEG.pm to make pause happy
 

--- a/lib/Media/DateTime/JPEG.pm
+++ b/lib/Media/DateTime/JPEG.pm
@@ -10,6 +10,7 @@ our $VERSION = '0.48';
 use Carp;
 use Image::ExifTool;
 use DateTime;
+use Scalar::Util 'blessed';
 use Try::Tiny;
 
 my $exifTool;
@@ -57,7 +58,7 @@ sub datetime {
         );
     }
     catch {
-        if (/to DateTime::new did not pass/) {
+        if ((blessed $_ && $_->isa('Specio::Exception')) || /to DateTime::new did not pass/) {
             warn
               "JPEG's DateTimeOriginal exif entry ($f) not a valid datetime.\n"
               . "Fallback to file timestamp.\n";


### PR DESCRIPTION
The error message thrown when parameters are invalid has changed a bit.
